### PR TITLE
Fix issue where removed routers were not deleted from cloudflare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,6 @@
 go.work
 
 config.y*ml
-state.yaml
+state.y*ml
 
 cmd/testing/

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -116,7 +116,7 @@ func DeleteSubdomain(routerIdentifier string) error {
 	}
 
 	for _, record := range records {
-		if len(record.Comment) >= 22 {
+		if len(record.Comment) >= len(commentMessage) {
 			substr := record.Comment[len(commentMessage):]
 			if substr == routerIdentifier {
 				err = cloudflareData.cloudflareAPI.DeleteDNSRecord(ctx, cloudflare.ZoneIdentifier(cloudflareData.zoneID), record.ID)


### PR DESCRIPTION
Fix a bug where Cloudflare DNS entries were not removed when deleting a router from the Traefik config.