### PR TITLE
Fix bug where WAN IP did not update on records

### DIFF
--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -71,7 +71,7 @@ func UpdateWanIP(s state) error {
 	}
 
 	for _, record := range records {
-		if len(record.Comment) >= 22 {
+		if len(record.Comment) >= 15 {
 			substr := record.Comment[len(commentMessage):]
 			_, ok := s.Routers[substr]
 			if ok {


### PR DESCRIPTION
Fixing bug where WAN IP would not be updated on records because the comment length check was too long.